### PR TITLE
refactor ripple interface

### DIFF
--- a/TrustWalletCore.xcodeproj/xcshareddata/xcschemes/TrustWalletCore_iOS.xcscheme
+++ b/TrustWalletCore.xcodeproj/xcshareddata/xcschemes/TrustWalletCore_iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TrustWalletCore.xcodeproj/xcshareddata/xcschemes/TrustWalletCore_macOS.xcscheme
+++ b/TrustWalletCore.xcodeproj/xcshareddata/xcschemes/TrustWalletCore_macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/wallet-core/include/TrustWalletCore/TWRippleSigner.h
+++ b/wallet-core/include/TrustWalletCore/TWRippleSigner.h
@@ -22,9 +22,9 @@ TW_Ripple_Proto_SigningOutput TWRippleSignerSign(TW_Ripple_Proto_SigningInput in
 
 /// Builds a message to be signed
 TW_EXPORT_STATIC_METHOD
-TWData *_Nonnull TWRippleSignerMessage(TW_Ripple_Proto_SigningInput data, TWData *_Nonnull pubKey);
+TWData *_Nonnull TWRippleSignerMessage(TW_Ripple_Proto_SigningInput data);
 /// Builds a transaction to be broadcasted
 TW_EXPORT_STATIC_METHOD
-TWData *_Nonnull TWRippleSignerTransaction(TW_Ripple_Proto_SigningInput data, TWData *_Nonnull pubKey, TWData *_Nonnull signature);
+TWData *_Nonnull TWRippleSignerTransaction(TW_Ripple_Proto_SigningInput data, TWData *_Nonnull signature);
 
 TW_EXTERN_C_END

--- a/wallet-core/swift/Sources/Generated/Protobuf/Ripple.pb.swift
+++ b/wallet-core/swift/Sources/Generated/Protobuf/Ripple.pb.swift
@@ -43,6 +43,9 @@ public struct TW_Ripple_Proto_SigningInput {
 
   public var privateKey: Data = SwiftProtobuf.Internal.emptyData
 
+  /// only used by tss chain-integration
+  public var publicKey: Data = SwiftProtobuf.Internal.emptyData
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -77,6 +80,7 @@ extension TW_Ripple_Proto_SigningInput: SwiftProtobuf.Message, SwiftProtobuf._Me
     7: .standard(proto: "destination_tag"),
     8: .same(proto: "flags"),
     9: .standard(proto: "private_key"),
+    10: .standard(proto: "public_key"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -91,6 +95,7 @@ extension TW_Ripple_Proto_SigningInput: SwiftProtobuf.Message, SwiftProtobuf._Me
       case 7: try decoder.decodeSingularInt64Field(value: &self.destinationTag)
       case 8: try decoder.decodeSingularInt64Field(value: &self.flags)
       case 9: try decoder.decodeSingularBytesField(value: &self.privateKey)
+      case 10: try decoder.decodeSingularBytesField(value: &self.publicKey)
       default: break
       }
     }
@@ -124,6 +129,9 @@ extension TW_Ripple_Proto_SigningInput: SwiftProtobuf.Message, SwiftProtobuf._Me
     if !self.privateKey.isEmpty {
       try visitor.visitSingularBytesField(value: self.privateKey, fieldNumber: 9)
     }
+    if !self.publicKey.isEmpty {
+      try visitor.visitSingularBytesField(value: self.publicKey, fieldNumber: 10)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -137,6 +145,7 @@ extension TW_Ripple_Proto_SigningInput: SwiftProtobuf.Message, SwiftProtobuf._Me
     if lhs.destinationTag != rhs.destinationTag {return false}
     if lhs.flags != rhs.flags {return false}
     if lhs.privateKey != rhs.privateKey {return false}
+    if lhs.publicKey != rhs.publicKey {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/wallet-core/swift/Sources/Generated/RippleSigner.swift
+++ b/wallet-core/swift/Sources/Generated/RippleSigner.swift
@@ -20,32 +20,24 @@ public final class RippleSigner {
         return try! TW_Ripple_Proto_SigningOutput(serializedData: resultData)
     }
 
-    public static func message(data: TW_Ripple_Proto_SigningInput, pubKey: Data) -> Data {
+    public static func message(data: TW_Ripple_Proto_SigningInput) -> Data {
         let dataData = TWDataCreateWithNSData(try! data.serializedData())
         defer {
             TWDataDelete(dataData)
         }
-        let pubKeyData = TWDataCreateWithNSData(pubKey)
-        defer {
-            TWDataDelete(pubKeyData)
-        }
-        return TWDataNSData(TWRippleSignerMessage(dataData, pubKeyData))
+        return TWDataNSData(TWRippleSignerMessage(dataData))
     }
 
-    public static func transaction(data: TW_Ripple_Proto_SigningInput, pubKey: Data, signature: Data) -> Data {
+    public static func transaction(data: TW_Ripple_Proto_SigningInput, signature: Data) -> Data {
         let dataData = TWDataCreateWithNSData(try! data.serializedData())
         defer {
             TWDataDelete(dataData)
-        }
-        let pubKeyData = TWDataCreateWithNSData(pubKey)
-        defer {
-            TWDataDelete(pubKeyData)
         }
         let signatureData = TWDataCreateWithNSData(signature)
         defer {
             TWDataDelete(signatureData)
         }
-        return TWDataNSData(TWRippleSignerTransaction(dataData, pubKeyData, signatureData))
+        return TWDataNSData(TWRippleSignerTransaction(dataData, signatureData))
     }
 
     let rawValue: OpaquePointer


### PR DESCRIPTION
refactor ripple interface so that we don't need pass public key on validating a transaction